### PR TITLE
Update user package with premium benefits

### DIFF
--- a/JOB_FINDER_API/Controllers/CompanySubscriptionController.cs
+++ b/JOB_FINDER_API/Controllers/CompanySubscriptionController.cs
@@ -1,4 +1,4 @@
-﻿using JOB_FINDER_API.Data;
+using JOB_FINDER_API.Data;
 using JOB_FINDER_API.Models;
 using JOB_FINDER_API.Models.Requests;
 using Microsoft.AspNetCore.Authorization;
@@ -234,16 +234,34 @@ namespace JOB_FINDER_API.Controllers
                     // Check if company has an active subscription
                     var existingSubscription = await _context.CompanySubscriptions
                         .Where(s => s.UserId == payment.UserId && s.IsActive && s.EndDate > DateTime.UtcNow)
+                        .Include(s => s.SubscriptionType)
                         .FirstOrDefaultAsync();
 
                     if (existingSubscription != null)
                     {
-                        // Update existing subscription
-                        existingSubscription.CompanySubscriptionTypeId = payment.SubscriptionTypeId; // Update to new subscription type
+                        // Get current subscription type
+                        var currentSubscriptionType = existingSubscription.SubscriptionType;
+                        
+                        // Only upgrade subscription type if the new one is higher tier, otherwise keep current tier
+                        bool shouldUpgradeSubscriptionType = subscriptionType.PackageType > currentSubscriptionType.PackageType;
+                        
+                        if (shouldUpgradeSubscriptionType)
+                        {
+                            // Upgrade to higher tier subscription
+                            existingSubscription.CompanySubscriptionTypeId = payment.SubscriptionTypeId;
+                            _logger.LogInformation($"Upgraded company subscription type from {currentSubscriptionType.PackageType} to {subscriptionType.PackageType} for user {payment.UserId}");
+                        }
+                        else
+                        {
+                            _logger.LogInformation($"Keeping current company subscription type {currentSubscriptionType.PackageType} (higher or equal to purchased {subscriptionType.PackageType}) for user {payment.UserId}");
+                        }
+                        
+                        // Always extend duration and add benefits regardless of tier
                         existingSubscription.EndDate = existingSubscription.EndDate.AddDays(subscriptionType.DurationInDays);
                         existingSubscription.RemainingJobPosts += subscriptionType.JobPostLimit;
                         existingSubscription.RemainingTrendingJobPosts += subscriptionType.TrendingJobLimit;
                         existingSubscription.UpdatedAt = DateTime.UtcNow;
+                        
                         _logger.LogInformation($"Extended company subscription for user {payment.UserId} until {existingSubscription.EndDate}, " +
                             $"added {subscriptionType.JobPostLimit} job posts and {subscriptionType.TrendingJobLimit} trending job posts");
                     }
@@ -313,16 +331,34 @@ namespace JOB_FINDER_API.Controllers
                 // Check if company has an active subscription
                 var existingSubscription = await _context.CompanySubscriptions
                     .Where(s => s.UserId == payment.UserId && s.IsActive && s.EndDate > DateTime.UtcNow)
+                    .Include(s => s.SubscriptionType)
                     .FirstOrDefaultAsync();
 
                 if (existingSubscription != null)
                 {
-                    // Update existing subscription
-                    existingSubscription.CompanySubscriptionTypeId = payment.SubscriptionTypeId; // Update to new subscription type
+                    // Get current subscription type
+                    var currentSubscriptionType = existingSubscription.SubscriptionType;
+                    
+                    // Only upgrade subscription type if the new one is higher tier, otherwise keep current tier
+                    bool shouldUpgradeSubscriptionType = subscriptionType.PackageType > currentSubscriptionType.PackageType;
+                    
+                    if (shouldUpgradeSubscriptionType)
+                    {
+                        // Upgrade to higher tier subscription
+                        existingSubscription.CompanySubscriptionTypeId = payment.SubscriptionTypeId;
+                        _logger.LogInformation($"Upgraded company subscription type from {currentSubscriptionType.PackageType} to {subscriptionType.PackageType} for user {payment.UserId}");
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"Keeping current company subscription type {currentSubscriptionType.PackageType} (higher or equal to purchased {subscriptionType.PackageType}) for user {payment.UserId}");
+                    }
+                    
+                    // Always extend duration and add benefits regardless of tier
                     existingSubscription.EndDate = existingSubscription.EndDate.AddDays(subscriptionType.DurationInDays);
                     existingSubscription.RemainingJobPosts += subscriptionType.JobPostLimit;
                     existingSubscription.RemainingTrendingJobPosts += subscriptionType.TrendingJobLimit;
                     existingSubscription.UpdatedAt = DateTime.UtcNow;
+                    
                     _logger.LogInformation($"Extended company subscription for user {payment.UserId} until {existingSubscription.EndDate}, " +
                         $"added {subscriptionType.JobPostLimit} job posts and {subscriptionType.TrendingJobLimit} trending job posts");
                 }

--- a/JOB_FINDER_API/Controllers/OthersController.cs
+++ b/JOB_FINDER_API/Controllers/OthersController.cs
@@ -1,4 +1,4 @@
-﻿using JOB_FINDER_API.Data;
+using JOB_FINDER_API.Data;
 using JOB_FINDER_API.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -223,19 +223,36 @@ namespace JOB_FINDER_API.Controllers
                             // Check if company has an active subscription
                             var existingSubscription = await _context.CompanySubscriptions
                                 .Where(s => s.UserId == payment.UserId && s.IsActive)
+                                .Include(s => s.SubscriptionType)
                                 .OrderByDescending(s => s.CreatedAt)
                                 .FirstOrDefaultAsync();
 
                             if (existingSubscription != null)
                             {
-                                // Update existing subscription
-                                existingSubscription.CompanySubscriptionTypeId = payment.SubscriptionTypeId; // Update the subscription type ID
+                                // Get current subscription type
+                                var currentSubscriptionType = existingSubscription.SubscriptionType;
+                                
+                                // Only upgrade subscription type if the new one is higher tier, otherwise keep current tier
+                                bool shouldUpgradeSubscriptionType = subscriptionType.PackageType > currentSubscriptionType.PackageType;
+                                
+                                if (shouldUpgradeSubscriptionType)
+                                {
+                                    // Upgrade to higher tier subscription
+                                    existingSubscription.CompanySubscriptionTypeId = payment.SubscriptionTypeId;
+                                    _logger.LogInformation($"Upgraded company subscription type from {currentSubscriptionType.PackageType} to {subscriptionType.PackageType} for user {payment.UserId}");
+                                }
+                                else
+                                {
+                                    _logger.LogInformation($"Keeping current company subscription type {currentSubscriptionType.PackageType} (higher or equal to purchased {subscriptionType.PackageType}) for user {payment.UserId}");
+                                }
+                                
+                                // Always add benefits and extend duration regardless of tier
                                 existingSubscription.RemainingJobPosts += subscriptionType.JobPostLimit;
                                 existingSubscription.RemainingTrendingJobPosts += subscriptionType.TrendingJobLimit;
                                 existingSubscription.UpdatedAt = DateTime.UtcNow;
-                                existingSubscription.EndDate = DateTime.UtcNow.AddDays(subscriptionType.DurationInDays);
+                                existingSubscription.EndDate = existingSubscription.EndDate.AddDays(subscriptionType.DurationInDays);
 
-                                _logger.LogInformation($"Updated company subscription for user {payment.UserId} to {subscriptionType.Name}, " +
+                                _logger.LogInformation($"Updated company subscription for user {payment.UserId}, " +
             $"added {subscriptionType.JobPostLimit} regular jobs and {subscriptionType.TrendingJobLimit} trending jobs");
                             }
                             else
@@ -274,18 +291,35 @@ namespace JOB_FINDER_API.Controllers
                             // Check if user has an active subscription
                             var existingSubscription = await _context.CandidateSubscriptions
                                 .Where(s => s.UserId == payment.UserId && s.IsActive)
+                                .Include(s => s.SubscriptionType)
                                 .OrderByDescending(s => s.CreatedAt)
                                 .FirstOrDefaultAsync();
 
                             if (existingSubscription != null)
                             {
-                                // Update existing subscription
-                                existingSubscription.SubscriptionTypeId = payment.SubscriptionTypeId; // Thêm dòng này để cập nhật SubscriptionTypeId
+                                // Get current subscription type
+                                var currentSubscriptionType = existingSubscription.SubscriptionType;
+                                
+                                // Only upgrade subscription type if the new one is higher tier, otherwise keep current tier
+                                bool shouldUpgradeSubscriptionType = subscriptionType.PackageType > currentSubscriptionType.PackageType;
+                                
+                                if (shouldUpgradeSubscriptionType)
+                                {
+                                    // Upgrade to higher tier subscription
+                                    existingSubscription.SubscriptionTypeId = payment.SubscriptionTypeId;
+                                    _logger.LogInformation($"Upgraded candidate subscription type from {currentSubscriptionType.PackageType} to {subscriptionType.PackageType} for user {payment.UserId}");
+                                }
+                                else
+                                {
+                                    _logger.LogInformation($"Keeping current candidate subscription type {currentSubscriptionType.PackageType} (higher or equal to purchased {subscriptionType.PackageType}) for user {payment.UserId}");
+                                }
+                                
+                                // Always add benefits and extend duration regardless of tier
                                 existingSubscription.RemainingTryMatches += subscriptionType.TryMatchLimit;
                                 existingSubscription.UpdatedAt = DateTime.UtcNow;
                                 existingSubscription.EndDate = DateTime.UtcNow.AddYears(10);
 
-                                _logger.LogInformation($"Updated candidate subscription for user {payment.UserId}, changed subscription type to {subscriptionType.Name}, added {subscriptionType.TryMatchLimit} try matches, total now: {existingSubscription.RemainingTryMatches}");
+                                _logger.LogInformation($"Updated candidate subscription for user {payment.UserId}, added {subscriptionType.TryMatchLimit} try matches, total now: {existingSubscription.RemainingTryMatches}");
                             }
                             else
                             {

--- a/JOB_FINDER_API/Controllers/PaymentController.cs
+++ b/JOB_FINDER_API/Controllers/PaymentController.cs
@@ -1,4 +1,4 @@
-﻿using JOB_FINDER_API.Data;
+using JOB_FINDER_API.Data;
 using JOB_FINDER_API.Models;
 using JOB_FINDER_API.Models.Requests;
 using Microsoft.AspNetCore.Authorization;
@@ -399,12 +399,30 @@ namespace JOB_FINDER_API.Controllers
                 // Check if user has an active subscription
                 var existingSubscription = await _context.CandidateSubscriptions
                     .Where(s => s.UserId == payment.UserId && s.IsActive)
+                    .Include(s => s.SubscriptionType)
                     .OrderByDescending(s => s.CreatedAt)
                     .FirstOrDefaultAsync();
 
                 if (existingSubscription != null)
                 {
-                    // Update existing subscription - just add more TryMatches
+                    // Get current subscription type
+                    var currentSubscriptionType = existingSubscription.SubscriptionType;
+                    
+                    // Only upgrade subscription type if the new one is higher tier, otherwise keep current tier
+                    bool shouldUpgradeSubscriptionType = subscriptionType.PackageType > currentSubscriptionType.PackageType;
+                    
+                    if (shouldUpgradeSubscriptionType)
+                    {
+                        // Upgrade to higher tier subscription
+                        existingSubscription.SubscriptionTypeId = payment.SubscriptionTypeId;
+                        _logger.LogInformation($"Upgraded candidate subscription type from {currentSubscriptionType.PackageType} to {subscriptionType.PackageType} for user {payment.UserId}");
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"Keeping current candidate subscription type {currentSubscriptionType.PackageType} (higher or equal to purchased {subscriptionType.PackageType}) for user {payment.UserId}");
+                    }
+                    
+                    // Always add benefits regardless of tier
                     existingSubscription.RemainingTryMatches += subscriptionType.TryMatchLimit;
                     existingSubscription.UpdatedAt = DateTime.UtcNow;
 
@@ -548,12 +566,30 @@ namespace JOB_FINDER_API.Controllers
                         // Check if user has an active subscription
                         var existingSubscription = await _context.CandidateSubscriptions
                             .Where(s => s.UserId == payment.UserId && s.IsActive)
+                            .Include(s => s.SubscriptionType)
                             .OrderByDescending(s => s.CreatedAt)
                             .FirstOrDefaultAsync();
 
                         if (existingSubscription != null)
                         {
-                            // Update existing subscription - just add more TryMatches
+                            // Get current subscription type
+                            var currentSubscriptionType = existingSubscription.SubscriptionType;
+                            
+                            // Only upgrade subscription type if the new one is higher tier, otherwise keep current tier
+                            bool shouldUpgradeSubscriptionType = subscriptionType.PackageType > currentSubscriptionType.PackageType;
+                            
+                            if (shouldUpgradeSubscriptionType)
+                            {
+                                // Upgrade to higher tier subscription
+                                existingSubscription.SubscriptionTypeId = payment.SubscriptionTypeId;
+                                _logger.LogInformation($"Upgraded candidate subscription type from {currentSubscriptionType.PackageType} to {subscriptionType.PackageType} for user {payment.UserId}");
+                            }
+                            else
+                            {
+                                _logger.LogInformation($"Keeping current candidate subscription type {currentSubscriptionType.PackageType} (higher or equal to purchased {subscriptionType.PackageType}) for user {payment.UserId}");
+                            }
+                            
+                            // Always add benefits regardless of tier
                             existingSubscription.RemainingTryMatches += subscriptionType.TryMatchLimit;
                             existingSubscription.UpdatedAt = DateTime.UtcNow;
                             existingSubscription.EndDate = DateTime.UtcNow.AddYears(10);
@@ -628,15 +664,34 @@ namespace JOB_FINDER_API.Controllers
             // Check if user has an active subscription
             var existingSubscription = await _context.CandidateSubscriptions
                 .Where(s => s.UserId == payment.UserId && s.IsActive && s.EndDate > DateTime.UtcNow)
+                .Include(s => s.SubscriptionType)
                 .FirstOrDefaultAsync();
 
             if (existingSubscription != null)
             {
-                // Extend existing subscription
+                // Get current subscription type
+                var currentSubscriptionType = existingSubscription.SubscriptionType;
+                
+                // Only upgrade subscription type if the new one is higher tier, otherwise keep current tier
+                bool shouldUpgradeSubscriptionType = subscriptionType.PackageType > currentSubscriptionType.PackageType;
+                
+                if (shouldUpgradeSubscriptionType)
+                {
+                    // Upgrade to higher tier subscription
+                    existingSubscription.SubscriptionTypeId = payment.SubscriptionTypeId;
+                    _logger.LogInformation($"Upgraded subscription type from {currentSubscriptionType.PackageType} to {subscriptionType.PackageType} for user {payment.UserId}");
+                }
+                else
+                {
+                    _logger.LogInformation($"Keeping current subscription type {currentSubscriptionType.PackageType} (higher or equal to purchased {subscriptionType.PackageType}) for user {payment.UserId}");
+                }
+                
+                // Always extend duration and add benefits regardless of tier
                 existingSubscription.EndDate = existingSubscription.EndDate.AddDays(subscriptionType.DurationInDays);
                 existingSubscription.RemainingTryMatches += subscriptionType.TryMatchLimit;
                 existingSubscription.UpdatedAt = DateTime.UtcNow;
-                _logger.LogInformation($"Extended subscription for user {payment.UserId} until {existingSubscription.EndDate}");
+                
+                _logger.LogInformation($"Extended subscription for user {payment.UserId} until {existingSubscription.EndDate}, added {subscriptionType.TryMatchLimit} try matches");
             }
             else
             {


### PR DESCRIPTION
Prevent subscription downgrades when purchasing a lower-tier package, ensuring users retain their current tier while accumulating benefits.

Previously, purchasing a lower-tier package (e.g., Basic) when already on a higher tier (e.g., Premium) would result in a downgrade. This update modifies the subscription logic to keep the existing higher tier and only add the benefits and extend the duration from the newly purchased package.

---
<a href="https://cursor.com/background-agent?bcId=bc-6beeed66-4e78-4902-969b-85f780ec3b13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6beeed66-4e78-4902-969b-85f780ec3b13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

