### PR TITLE
Check for pending applications on inactive jobs

### DIFF
--- a/JOB_FINDER_API/Controllers/CompanyProfileController.cs
+++ b/JOB_FINDER_API/Controllers/CompanyProfileController.cs
@@ -125,6 +125,21 @@ namespace JOB_FINDER_API.Controllers
             if (company == null)
                 return NotFound("Company not found.");
 
+            // Check if company has jobs with pending applications
+            var hasPendingApplications = await _context.Jobs
+                .Where(j => j.CompanyId == userId)
+                .SelectMany(j => j.Applications)
+                .AnyAsync(a => a.Status == ApplicationStatus.Pending);
+
+            if (hasPendingApplications)
+            {
+                return BadRequest(new { 
+                    Success = false, 
+                    ErrorMessage = "Không thể vô hiệu hóa công ty vì còn đơn ứng tuyển đang chờ xử lý. Vui lòng xử lý tất cả đơn ứng tuyển trước khi vô hiệu hóa công ty.",
+                    ErrorCode = "PENDING_APPLICATIONS_EXIST"
+                });
+            }
+
             company.IsActive = false;
             await _context.SaveChangesAsync();
             return Ok("Company has been locked.");
@@ -140,6 +155,37 @@ namespace JOB_FINDER_API.Controllers
             company.IsActive = true;
             await _context.SaveChangesAsync();
             return Ok("Company has been unlocked.");
+        }
+
+        [HttpGet("{userId}/pending-applications")]
+        public async Task<IActionResult> GetPendingApplications(int userId)
+        {
+            var company = await _context.CompanyProfile.FindAsync(userId);
+            if (company == null)
+                return NotFound("Company not found.");
+
+            var pendingApplications = await _context.Jobs
+                .Where(j => j.CompanyId == userId)
+                .SelectMany(j => j.Applications)
+                .Where(a => a.Status == ApplicationStatus.Pending)
+                .Select(a => new {
+                    ApplicationId = a.ApplicationId,
+                    JobId = a.JobId,
+                    JobTitle = a.Job.Title,
+                    ApplicantName = a.User.FullName,
+                    ApplicantEmail = a.User.Email,
+                    SubmittedAt = a.SubmittedAt,
+                    SimilarityScore = a.SimilarityScore
+                })
+                .OrderByDescending(a => a.SubmittedAt)
+                .ToListAsync();
+
+            return Ok(new {
+                CompanyId = userId,
+                CompanyName = company.CompanyName,
+                PendingApplicationsCount = pendingApplications.Count,
+                PendingApplications = pendingApplications
+            });
         }
 
         [HttpPost]

--- a/JOB_FINDER_API/Controllers/JobController.cs
+++ b/JOB_FINDER_API/Controllers/JobController.cs
@@ -1,4 +1,4 @@
-﻿using JOB_FINDER_API.Data;
+using JOB_FINDER_API.Data;
 using JOB_FINDER_API.Hubs;
 using JOB_FINDER_API.Models;
 using JOB_FINDER_API.Models.DTO;
@@ -1347,6 +1347,19 @@ namespace JOB_FINDER_API.Controllers
 
                     if (job.Status == Job.JobStatus.active && newStatus == Job.JobStatus.inactive)
                     {
+                        // Check if job has pending applications
+                        var hasPendingApplications = await _context.Applications
+                            .AnyAsync(a => a.JobId == id && a.Status == ApplicationStatus.Pending);
+
+                        if (hasPendingApplications)
+                        {
+                            return BadRequest(new { 
+                                Success = false, 
+                                ErrorMessage = "Không thể vô hiệu hóa công việc vì còn đơn ứng tuyển đang chờ xử lý. Vui lòng xử lý tất cả đơn ứng tuyển trước khi vô hiệu hóa công việc.",
+                                ErrorCode = "PENDING_APPLICATIONS_EXIST"
+                            });
+                        }
+
                         job.Status = Job.JobStatus.inactive;
                         job.DeactivatedByAdmin = false;
 
@@ -1392,6 +1405,21 @@ namespace JOB_FINDER_API.Controllers
             if (job == null)
                 return NotFound("Job not found.");
 
+            string warningMessage = null;
+
+            // Check for pending applications when locking
+            if (isLock && job.Status == Job.JobStatus.active)
+            {
+                var pendingApplicationsCount = await _context.Applications
+                    .CountAsync(a => a.JobId == id && a.Status == ApplicationStatus.Pending);
+
+                if (pendingApplicationsCount > 0)
+                {
+                    warningMessage = $"Warning: This job has {pendingApplicationsCount} pending application(s) that may need attention.";
+                    _logger.LogWarning($"Admin locking job #{id} which has {pendingApplicationsCount} pending applications");
+                }
+            }
+
             job.DeactivatedByAdmin = isLock;
 
             if (isLock && job.Status == Job.JobStatus.active)
@@ -1401,7 +1429,14 @@ namespace JOB_FINDER_API.Controllers
             await _context.SaveChangesAsync();
             _logger.LogInformation($"Job #{id} {(isLock ? "locked" : "unlocked")} by admin");
 
-            return Ok(isLock ? "Job has been locked by admin." : "Job has been unlocked by admin.");
+            var response = new
+            {
+                Success = true,
+                Message = isLock ? "Job has been locked by admin." : "Job has been unlocked by admin.",
+                Warning = warningMessage
+            };
+
+            return Ok(response);
         }
 
 
@@ -1962,8 +1997,53 @@ namespace JOB_FINDER_API.Controllers
             return Ok(result);
         }
 
+        [HttpGet("{jobId}/pending-applications")]
+        public async Task<IActionResult> GetJobPendingApplications(int jobId)
+        {
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (!int.TryParse(userIdClaim, out var userId))
+                return Unauthorized("Invalid user ID.");
 
+            var job = await _context.Jobs.FindAsync(jobId);
+            if (job == null)
+                return NotFound("Job not found.");
 
+            var role = User.FindFirst(ClaimTypes.Role)?.Value?.ToLower();
+
+            // Only company owner or admin can view pending applications
+            if (role == "company" && job.CompanyId != userId)
+                return Forbid("You can only view pending applications for your own jobs.");
+            else if (role != "company" && role != "admin")
+                return Forbid("You do not have permission to view job applications.");
+
+            var pendingApplications = await _context.Applications
+                .Where(a => a.JobId == jobId && a.Status == ApplicationStatus.Pending)
+                .Include(a => a.User)
+                .Select(a => new {
+                    ApplicationId = a.ApplicationId,
+                    JobId = a.JobId,
+                    ApplicantId = a.UserId,
+                    ApplicantName = a.User.FullName,
+                    ApplicantEmail = a.User.Email,
+                    ResumeUrl = a.ResumeUrl,
+                    CoverLetter = a.CoverLetter,
+                    SubmittedAt = a.SubmittedAt,
+                    SimilarityScore = a.SimilarityScore,
+                    SimilarityDescription = a.SimilarityDescription,
+                    SimilaritySkills = a.SimilaritySkills,
+                    SimilarityExperience = a.SimilarityExperience,
+                    SimilarityEducation = a.SimilarityEducation
+                })
+                .OrderByDescending(a => a.SubmittedAt)
+                .ToListAsync();
+
+            return Ok(new {
+                JobId = jobId,
+                JobTitle = job.Title,
+                PendingApplicationsCount = pendingApplications.Count,
+                PendingApplications = pendingApplications
+            });
+        }
 
     }
 }

--- a/JOB_FINDER_API/Controllers/UserController.cs
+++ b/JOB_FINDER_API/Controllers/UserController.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using JOB_FINDER_API.Data;
@@ -165,6 +165,24 @@ namespace JOB_FINDER_API.Controllers
 
             if (user.Role.RoleName.Equals("Admin", StringComparison.OrdinalIgnoreCase))
                 return BadRequest("Cannot lock an admin account.");
+
+            // Check if user is a company and has pending applications
+            if (user.Role.RoleName.Equals("Company", StringComparison.OrdinalIgnoreCase))
+            {
+                var hasPendingApplications = await _dbContext.Jobs
+                    .Where(j => j.CompanyId == id)
+                    .SelectMany(j => j.Applications)
+                    .AnyAsync(a => a.Status == Models.ApplicationStatus.Pending);
+
+                if (hasPendingApplications)
+                {
+                    return BadRequest(new { 
+                        Success = false, 
+                        ErrorMessage = "Không thể vô hiệu hóa tài khoản công ty vì còn đơn ứng tuyển đang chờ xử lý. Vui lòng xử lý tất cả đơn ứng tuyển trước khi vô hiệu hóa tài khoản.",
+                        ErrorCode = "PENDING_APPLICATIONS_EXIST"
+                    });
+                }
+            }
 
             user.IsActive = false;
             user.UpdatedAt = DateTime.UtcNow;


### PR DESCRIPTION
Add validation to prevent company/user deactivation if pending job applications exist and provide an endpoint to view them.

The current system allows companies or company-associated users to be deactivated even if they have active job postings with pending applications. This PR introduces checks to prevent such deactivation, ensuring that all applications are processed, and provides a new API endpoint for administrators to easily review these pending applications.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc0ccab8-d197-4b6a-b3bd-52f9f0dd3815">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc0ccab8-d197-4b6a-b3bd-52f9f0dd3815">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

